### PR TITLE
Fix broken error message

### DIFF
--- a/restfly/utils.py
+++ b/restfly/utils.py
@@ -415,7 +415,7 @@ def check(  # noqa: C901
     def validate_choice_list(choices, obj):
         if obj not in choices:
             raise UnexpectedValueError((
-                f'{name} has value of {obj}.  Expected one of '
+                f'{name} has value of {obj}.  Expected one of ' + 
                 ','.join([str(i) for i in choices])
             ))
 

--- a/restfly/utils.py
+++ b/restfly/utils.py
@@ -415,8 +415,8 @@ def check(  # noqa: C901
     def validate_choice_list(choices, obj):
         if obj not in choices:
             raise UnexpectedValueError((
-                f'{name} has value of {obj}.  Expected one of ' + 
-                ','.join([str(i) for i in choices])
+                f'{name} has value of {obj}.  Expected one of '
+                f'{",".join([str(i) for i in choices])}'
             ))
 
     def validate_expected_type(expected, obj, softcheck=True):


### PR DESCRIPTION
Hi, i noticed some malformed error message when `UnexpectedValueError` is raised by `validate_choice_list` method in utils.py

The message seems broked from commit 6696617a6bfe19b5995d9819ce7369c39042f507, since it works before (commit cfca06a9bac0c99ad5efd86ef62931a884259faa).

Using cfca06a9bac0c99ad5efd86ef62931a884259faa:
```python
python3 /tmp/b.py                                                                                 ─╯
Traceback (most recent call last):
  File "/tmp/b.py", line 8, in <module>
    raise Exception(
Exception: name has value of obj.  Expected one of helloWorld,BAR
```

Using 6696617a6bfe19b5995d9819ce7369c39042f507 (malformed message):
```python
Traceback (most recent call last):
  File "/tmp/b.py", line 4, in <module>
    raise Exception((
Exception: helloWorldname has value of obj.  Expected one of ,BAR
```